### PR TITLE
Only return errors in datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ check "valid_check" {
 ## Datasource case
 
 ```
-data "aws_iam_validator_policy" "example" {
+data "aws-iam-validator" "example" {
   policy_json = <<EOF
   {
     "Version": "2012-10-17",
@@ -28,6 +28,6 @@ data "aws_iam_validator_policy" "example" {
 }
 
 output "findings" {
-  value = data.aws_iam_validator_policy.example.findings
+  value = data.aws-iam-validator.example.findings
 }
 ```

--- a/internal/provider/datasource_iam_validate.go
+++ b/internal/provider/datasource_iam_validate.go
@@ -75,8 +75,10 @@ func (d *ValidatePolicyDataSource) Read(ctx context.Context, req datasource.Read
 
 	findings := []string{}
 	for _, finding := range result.Findings {
-		msg, _ := json.Marshal(finding)
-		findings = append(findings, string(msg))
+		if finding.FindingType == awstypes.ValidatePolicyFindingTypeError {
+			msg, _ := json.Marshal(finding)
+			findings = append(findings, string(msg))
+		}
 	}
 
 	data.Findings = findings


### PR DESCRIPTION
Only return errors in datasource instead of any kind of policy finding.